### PR TITLE
support for tagged strings like "{ref}123"

### DIFF
--- a/src/functorpack/FPack.mli
+++ b/src/functorpack/FPack.mli
@@ -203,6 +203,25 @@ module Figly : sig
         else that also defines the same [data] type.
      *)
 
+  val decode_tagged_string : bytes -> int -> int ->
+                             (string * int * int) option
+    (** [decode_tagged_string bytes pos len]:
+        Decodes a string that optionally uses the "{tag}" prefix.
+        Returns [None] when there is no such prefix.
+        Returns [Some(tag,p,l)[ when the prefix with [tag] is found,
+        and the payload starts at byte [p] and the length is [l].
+        Raises [Cannot_represent] if there is a left brace but not a right
+        brace.
+     *)
+
+  val encode_tagged_string_str : string -> string
+    (** Checks whether this string needs the "{str}" prefix and
+        prepends it if necessary.
+     *)
+
+  val encode_tagged_string_ref : string -> string
+    (** Encodes a ref to the passed ID as tagged string *)
+
 end
 
 


### PR DESCRIPTION
This PR implements the tagged string representation introduced in https://github.com/figly/datasearch/pull/189.
