### PR TITLE
allow '{' at beginning of strings even if not a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You need:
  - `ocaml setup.ml -configure`
  - `omake`
  - `progs/unittests`  (optional)
+ - `omake uninstall` (if already installed)
  - `omake install`
 
 ## Documentation

--- a/src/functorpack/modules/Figly.ml
+++ b/src/functorpack/modules/Figly.ml
@@ -39,11 +39,12 @@ let decode_tagged_string by pos len =
     match Bytes.index_from by (pos+1) '}' with
       | i ->
           if i >= pos+len then
-            failwith "FPack.Figly.decompose_tagged_string";
-          let tag = Bytes.sub_string by (pos+1) (i-pos-1) in
-          Some(tag,i+1,pos+len-i-1)
+            None
+          else
+            let tag = Bytes.sub_string by (pos+1) (i-pos-1) in
+            Some(tag,i+1,pos+len-i-1)
       | exception Not_found ->
-          failwith "FPack.Figly.decompose_tagged_string"
+          None
 
 let encode_tagged_string_str s =
   if String.length s > 0 && s.[0] = '{' then


### PR DESCRIPTION
With the new fixed-set-of-tags approach, we allow unescaped strings to have invalid tags -- eg, the literal strings `"{foo}"` or `"{ref"` are allowed without a `{str}` prefix. The messagepack decoder should treat these as plain strings rather than raise an exception.